### PR TITLE
WIP Performance improvements to current implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development do
   gem "rake"
   gem "benchmark-ips"
   gem "benchmark-memory"
+  gem "memory_profiler"
   gem "fuzzbert"
 end
 

--- a/Steepfile
+++ b/Steepfile
@@ -1,0 +1,5 @@
+target :lib do
+  signature "sig"
+
+  check "lib"
+end

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -6,6 +6,9 @@ require "bundler/setup"
 require "benchmark/ips"
 require "benchmark/memory"
 require "hashids"
+require "memory_profiler"
+
+my_salt = "salt!"
 
 def run_check(title, &block)
   puts "\n\n# #{title}:"
@@ -16,45 +19,55 @@ def run_check(title, &block)
   Benchmark.memory(&block)
 end
 
-my_salt = "salt!"
-
-run_check("Longer alphabets are slower") do |x|
+run_check("#encode") do |x|
   coder = ::Hashids.new(my_salt)
-  # coder2 = ::Hashids.new(my_salt, 0, "1234567890abcdef")
-  coder21 = ::Hashids2.new(my_salt)
-  # coder22 = ::Hashids2.new(my_salt, 0, "1234567890abcdef")
+  coderv2 = ::Hashids2.new(my_salt)
 
   input = 100.times.map { rand(1000) }.freeze
 
-  x.report("default alphabet") { coder.encode(input) }
-  # x.report("custom shorter alphabet") { coder2.encode(input) }
-  x.report("v2 default alphabet") { coder21.encode(input) }
-  # x.report("v2 custom shorter alphabet") { coder22.encode(input) }
+  x.report("v1") { coder.encode(input) }
+  x.report("v2") { coderv2.encode(input) }
 
   x.compare!
 end
 
-#
-# run_check("Longer salts don't change much") do |x|
-#   coder = ::Hashids.new(my_salt)
-#   coder2 = ::Hashids.new("a" * 100)
-#
-#   x.report("default salt") { coder.encode([78, 45]) }
-#   x.report("longer salt") { coder2.encode([78, 45]) }
-#
-#   x.compare!
-# end
-#
-# run_check("target length") do |x|
-#   coder0 = ::Hashids.new(my_salt, 0)
-#   coder = ::Hashids.new(my_salt, 8)
-#   coder2 = ::Hashids.new(my_salt, 16)
-#   coder3 = ::Hashids.new(my_salt, 32)
-#
-#   x.report("min length") { coder0.encode([78, 45]) }
-#   x.report("length 8") { coder.encode([78, 45]) }
-#   x.report("length 16") { coder2.encode([78, 45]) }
-#   x.report("length 32") { coder3.encode([78, 45]) }
-#
-#   x.compare!
-# end
+puts "\n\n\n------ small input -------"
+
+coder = ::Hashids.new(my_salt)
+coderv2 = ::Hashids2.new(my_salt)
+input = [1]
+
+report = MemoryProfiler.report do
+  coder.encode(input)
+end
+
+report.pretty_print
+
+puts "-------------"
+report = MemoryProfiler.report do
+  coderv2.encode(input)
+end
+
+report.pretty_print
+
+puts "\n\n\n------large input -------"
+
+input = 100.times.map { rand(1000) }.freeze
+
+report = MemoryProfiler.report do
+  coder.encode(input)
+end
+
+report.pretty_print
+
+puts "-------------"
+report = MemoryProfiler.report do
+  coderv2.encode(input)
+end
+
+report.pretty_print
+
+puts "-------------"
+
+
+

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -19,6 +19,13 @@ def run_check(title, &block)
   Benchmark.memory(&block)
 end
 
+run_check(".new") do |x|
+  x.report("v1") { ::Hashids.new(my_salt) }
+  x.report("v2") { ::Hashids2.new(my_salt) }
+
+  x.compare!
+end
+
 run_check("#encode") do |x|
   coder = ::Hashids.new(my_salt)
   coderv2 = ::Hashids2.new(my_salt)
@@ -31,7 +38,41 @@ run_check("#encode") do |x|
   x.compare!
 end
 
-puts "\n\n\n------ small input -------"
+run_check("#decode") do |x|
+  coder = ::Hashids.new(my_salt)
+  coderv2 = ::Hashids2.new(my_salt)
+
+  input = coderv2.encode(rand(1000))
+
+  x.report("v1") { coder.decode(input) }
+  x.report("v2") { coderv2.decode(input) }
+
+  x.compare!
+end
+
+run_check("#encode_hex") do |x|
+  coder = ::Hashids.new(my_salt)
+  coderv2 = ::Hashids2.new(my_salt)
+
+  input = rand(1000).to_s(16)
+
+  x.report("v1") { coder.encode_hex(input) }
+  x.report("v2") { coderv2.encode_hex(input) }
+
+  x.compare!
+end
+
+run_check("#decode_hex") do |x|
+  coder = ::Hashids.new(my_salt)
+  coderv2 = ::Hashids2.new(my_salt)
+
+  input = coderv2.encode_hex(rand(1000).to_s(16))
+
+  x.report("v1") { coder.decode_hex(input) }
+  x.report("v2") { coderv2.decode_hex(input) }
+
+  x.compare!
+end
 
 coder = ::Hashids.new(my_salt)
 coderv2 = ::Hashids2.new(my_salt)

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+
+require "benchmark/ips"
+require "benchmark/memory"
+require "hashids"
+
+def run_check(title, &block)
+  puts "\n\n# #{title}:"
+  puts "-------------------\n\n"
+
+  Benchmark.ips(time: 3, warmup: 1, &block)
+  puts "\n\n## Memory:\n\n"
+  Benchmark.memory(&block)
+end
+
+my_salt = "salt!"
+
+run_check("Longer alphabets are slower") do |x|
+  coder = ::Hashids.new(my_salt)
+  # coder2 = ::Hashids.new(my_salt, 0, "1234567890abcdef")
+  coder21 = ::Hashids2.new(my_salt)
+  # coder22 = ::Hashids2.new(my_salt, 0, "1234567890abcdef")
+
+  input = 100.times.map { rand(1000) }.freeze
+
+  x.report("default alphabet") { coder.encode(input) }
+  # x.report("custom shorter alphabet") { coder2.encode(input) }
+  x.report("v2 default alphabet") { coder21.encode(input) }
+  # x.report("v2 custom shorter alphabet") { coder22.encode(input) }
+
+  x.compare!
+end
+
+#
+# run_check("Longer salts don't change much") do |x|
+#   coder = ::Hashids.new(my_salt)
+#   coder2 = ::Hashids.new("a" * 100)
+#
+#   x.report("default salt") { coder.encode([78, 45]) }
+#   x.report("longer salt") { coder2.encode([78, 45]) }
+#
+#   x.compare!
+# end
+#
+# run_check("target length") do |x|
+#   coder0 = ::Hashids.new(my_salt, 0)
+#   coder = ::Hashids.new(my_salt, 8)
+#   coder2 = ::Hashids.new(my_salt, 16)
+#   coder3 = ::Hashids.new(my_salt, 32)
+#
+#   x.report("min length") { coder0.encode([78, 45]) }
+#   x.report("length 8") { coder.encode([78, 45]) }
+#   x.report("length 16") { coder2.encode([78, 45]) }
+#   x.report("length 32") { coder3.encode([78, 45]) }
+#
+#   x.compare!
+# end

--- a/hashids.gemspec
+++ b/hashids.gemspec
@@ -1,7 +1,6 @@
 # encoding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'hashids'
+
+require_relative "lib/hashids/version"
 
 Gem::Specification.new do |gem|
   gem.name          = "hashids"

--- a/lib/hashids.rb
+++ b/lib/hashids.rb
@@ -1,10 +1,11 @@
 # encoding: utf-8
 
+# require "crystalruby"
 require_relative 'hashids2'
+require_relative 'hashids3'
+require_relative "hashids/version"
 
 class Hashids
-  VERSION = "1.0.6"
-
   MIN_ALPHABET_LENGTH = 16
   SEP_DIV             = 3.5
   GUARD_DIV           = 12.0

--- a/lib/hashids/version.rb
+++ b/lib/hashids/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Hashids
+  VERSION = "1.0.6"
+end

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -65,7 +65,7 @@ class Hashids2
   protected
 
   def internal_encode(numbers)
-    alphabet = @alphabet
+    alphabet = @alphabet.chars
     alphabet_length = alphabet.length
     length   = numbers.length
 
@@ -75,7 +75,7 @@ class Hashids2
 
     lottery = alphabet[hash_int % alphabet_length]
     ret = lottery.dup
-    seasoning = lottery + salt
+    seasoning = (lottery + salt).chars
 
     numbers.each_with_index do |num, i|
       buf = seasoning + alphabet
@@ -103,8 +103,8 @@ class Hashids2
 
     while(ret.length < min_hash_length)
       alphabet = consistent_shuffle(alphabet, alphabet)
-      ret.prepend(alphabet[half_length .. -1])
-      ret << alphabet[0, half_length]
+      ret.prepend(*alphabet[half_length .. -1])
+      ret.concat(*alphabet[0, half_length])
 
       excess = ret.length - min_hash_length
       ret = ret[excess / 2, min_hash_length] if excess > 0
@@ -142,11 +142,13 @@ class Hashids2
     ret
   end
 
+  # Keep alphabet and salt as arrays internally
   def consistent_shuffle(alphabet, salt)
-    return alphabet if salt.nil? || salt.empty?
+    chars = alphabet.dup
 
-    chars = alphabet.each_char.to_a
-    salt_ords = salt.codepoints.to_a
+    return chars if salt.nil? || salt.empty?
+
+    salt_ords = salt.map(&:ord)
     salt_length = salt_ords.length
     idx = ord_total = 0
 
@@ -159,7 +161,7 @@ class Hashids2
       idx = (idx + 1) % salt_length
     end
 
-    chars.join
+    chars
   end
 
   def hash_one_number(num, alphabet, alphabet_length)

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -28,6 +28,8 @@ class Hashids2
     @alphabet         = alphabet.freeze
 
     validate_attributes
+
+    @salt_chars       = salt.chars
     setup_alphabet
   end
 
@@ -79,8 +81,9 @@ class Hashids2
     end
 
     lottery = current_alphabet[hash_int % alphabet_length]
+
     ret = lottery.dup
-    seasoning = (lottery + salt).chars
+    seasoning = [lottery].concat(@salt_chars)
 
     numbers.each_with_index do |num, i|
       buf = seasoning + current_alphabet

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -58,14 +58,13 @@ class Hashids2
   end
 
   def decode_hex(hash)
-    ret = ""
     numbers = decode(hash)
 
-    numbers.length.times do |i|
-      ret += numbers[i].to_s(16)[1 .. -1]
+    ret = numbers.map do |n|
+      n.to_s(16)[1 .. -1]
     end
 
-    ret.upcase
+    ret.join.upcase
   end
 
   protected

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -1,8 +1,8 @@
+# frozen_string_literal: true
+
 # encoding: utf-8
 
-require_relative 'hashids2'
-
-class Hashids
+class Hashids2
   VERSION = "1.0.6"
 
   MIN_ALPHABET_LENGTH = 16

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -159,7 +159,8 @@ class Hashids2
 
     idx = ord_total = 0
 
-    (collection_to_shuffle.length-1).downto(1) do |i|
+    i = collection_to_shuffle.length-1
+    while i >= 1
       raise ArgumentError, "Salt is too short in shuffle" if idx >= salt_part_1_length && salt_part_2.nil?
       ord_total += n = (idx >= salt_part_1_length ? salt_part_2[idx - salt_part_1_length] : salt_part_1[idx]).ord
       j = (n + idx + ord_total) % i
@@ -167,6 +168,7 @@ class Hashids2
       chars[i], chars[j] = chars[j], chars[i]
 
       idx = (idx + 1) % max_salt_length
+      i -= 1
     end
 
     chars

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -165,7 +165,9 @@ class Hashids2
       ord_total += n = (idx >= salt_part_1_length ? salt_part_2[idx - salt_part_1_length] : salt_part_1[idx]).ord
       j = (n + idx + ord_total) % i
 
-      chars[i], chars[j] = chars[j], chars[i]
+      tmp = chars[i]
+      chars[i] = chars[j]
+      chars[j] = tmp
 
       idx = (idx + 1) % max_salt_length
       i -= 1

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -135,7 +135,7 @@ class Hashids2
       breakdown = breakdown[1 .. -1].tr(@escaped_seps_selector, " ")
       array     = breakdown.split(" ")
 
-      seasoning = (lottery + salt).chars
+      seasoning = [lottery].concat(@salt_chars)
 
       array.length.times do |time|
         sub_hash = array[time]
@@ -153,17 +153,16 @@ class Hashids2
     ret
   end
 
-  def consistent_shuffle(collection_to_shuffle, salt)
+  def consistent_shuffle(collection_to_shuffle, shuffle_salt)
     chars = collection_to_shuffle.dup
 
-    return chars if salt.nil? || salt.empty?
+    return chars if shuffle_salt.nil? || shuffle_salt.empty?
 
-    salt_ords = salt.map(&:ord)
-    salt_length = salt_ords.length
+    salt_length = shuffle_salt.length
     idx = ord_total = 0
 
     (collection_to_shuffle.length-1).downto(1) do |i|
-      ord_total += n = salt_ords[idx]
+      ord_total += n = shuffle_salt[idx].ord
       j = (n + idx + ord_total) % i
 
       chars[i], chars[j] = chars[j], chars[i]
@@ -232,7 +231,7 @@ class Hashids2
     @alphabet.delete!(' ')
     @seps.delete!(' ')
 
-    @seps = consistent_shuffle(@seps.chars, salt.chars).join
+    @seps = consistent_shuffle(@seps.chars, @salt_chars).join
 
     if @seps.length == 0 || (@alphabet.length / @seps.length.to_f) > SEP_DIV
       seps_length = (@alphabet.length / SEP_DIV).ceil
@@ -248,7 +247,7 @@ class Hashids2
       end
     end
 
-    @alphabet = consistent_shuffle(@alphabet.chars, salt.chars)
+    @alphabet = consistent_shuffle(@alphabet.chars, @salt_chars)
   end
 
   def setup_guards

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -76,10 +76,11 @@ class Hashids2
     alphabet_length = current_alphabet.length
     length   = numbers.length
 
-    hash_int = numbers.each_with_index.sum(0) do |n, i|
-      n % (i + 100)
+    hash_int = 0
+    # We dont use the iterator#sum to avoid the extra array allocation
+    numbers.each_with_index do |n, i|
+      hash_int += n % (i + 100)
     end
-
     lottery = current_alphabet[hash_int % alphabet_length]
 
     ret = lottery.dup

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -151,15 +151,15 @@ class Hashids2
   end
 
   def consistent_shuffle(collection_to_shuffle, salt_part_1, salt_part_2, max_salt_length)
-    chars = collection_to_shuffle.dup
-
     salt_part_1_length = salt_part_1.length
 
-    return chars if collection_to_shuffle.empty? || max_salt_length == 0 || salt_part_1.nil? || salt_part_1_length == 0
+    return collection_to_shuffle if collection_to_shuffle.empty? || max_salt_length == 0 || salt_part_1.nil? || salt_part_1_length == 0
+
+    chars = collection_to_shuffle.dup
 
     idx = ord_total = 0
 
-    i = collection_to_shuffle.length-1
+    i = collection_to_shuffle.length - 1
     while i >= 1
       raise ArgumentError, "Salt is too short in shuffle" if idx >= salt_part_1_length && salt_part_2.nil?
       ord_total += n = (idx >= salt_part_1_length ? salt_part_2[idx - salt_part_1_length] : salt_part_1[idx]).ord

--- a/lib/hashids2.rb
+++ b/lib/hashids2.rb
@@ -9,19 +9,20 @@ class Hashids2
   SEP_DIV             = 3.5
   GUARD_DIV           = 12.0
 
-  DEFAULT_SEPS        = "cfhistuCFHISTU"
+  DEFAULT_SEPS        = "cfhistuCFHISTU".freeze
 
-  DEFAULT_ALPHABET    = "abcdefghijklmnopqrstuvwxyz" +
+  DEFAULT_ALPHABET    = ("abcdefghijklmnopqrstuvwxyz" +
                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
-                        "1234567890"
+                        "1234567890").freeze
 
   attr_reader :salt, :min_hash_length, :alphabet, :seps, :guards
 
   def initialize(salt = "", min_hash_length = 0, alphabet = DEFAULT_ALPHABET)
     @salt             = salt
     @min_hash_length  = min_hash_length
-    @alphabet         = alphabet
+    @alphabet         = alphabet.freeze
 
+    validate_attributes
     setup_alphabet
   end
 
@@ -192,9 +193,7 @@ class Hashids2
   private
 
   def setup_alphabet
-    validate_attributes
-
-    @alphabet = String.new(uniq_characters(alphabet))
+    @alphabet = uniq_characters(alphabet)
 
     validate_alphabet
 
@@ -206,7 +205,7 @@ class Hashids2
   end
 
   def setup_seps
-    @seps = String.new(DEFAULT_SEPS)
+    @seps = DEFAULT_SEPS.dup
 
     seps.length.times do |i|
       # Seps should only contain characters present in alphabet,

--- a/spec/hashids2_spec.rb
+++ b/spec/hashids2_spec.rb
@@ -1,0 +1,327 @@
+# encoding: utf-8
+
+require "minitest/autorun"
+require "minitest/spec"
+
+require_relative "../lib/hashids2"
+
+describe Hashids2 do
+  let(:salt)              { 'this is my salt' }
+  let(:seps)              { 'UHuhtcITCsFifS'  }
+  let(:guards)            { 'AdG0'            }
+  let(:hashids)           { Hashids2.new(salt) }
+
+  let(:default_seps) {
+    "cfhistuCFHISTU"
+  }
+
+  let(:default_alphabet)  {
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+  }
+
+  let(:alphabet)          {
+    "5N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7"
+  }
+
+  describe "setup" do
+    it "has a default alphabet" do
+      _(Hashids2::DEFAULT_ALPHABET).must_equal default_alphabet
+    end
+
+    it "has default separators" do
+      _(Hashids2::DEFAULT_SEPS).must_equal default_seps
+    end
+
+    it "has a default salt" do
+      _(Hashids2.new.encode(1,2,3)).must_equal "o2fXhV"
+    end
+
+    it "has the correct salt" do
+      _(hashids.instance_variable_get(:@salt)).must_equal salt
+    end
+
+    it "defaults to a min_length of 0" do
+      _(hashids.instance_variable_get(:@min_hash_length)).must_equal 0
+    end
+
+    it "generates the correct seps" do
+      _(hashids.instance_variable_get(:@seps)).must_equal seps.chars
+    end
+
+    it "generates the correct @guards" do
+      _(hashids.instance_variable_get(:@guards)).must_equal guards.chars
+    end
+
+    it "generates the correct alphabet" do
+      _(hashids.instance_variable_get(:@alphabet)).must_equal alphabet.chars
+    end
+
+    it "has a minimum alphabet length" do
+      _(-> {
+        Hashids2.new("", 0, 'shortalphabet')
+      }).must_raise Hashids2::AlphabetError
+    end
+
+    it "has a final alphabet length that can be shorter than the minimum" do
+      _(Hashids2.new("this is my salt", 0, 'cfhistuCFHISTU01').
+        alphabet).must_equal "10"
+    end
+
+    it "checks the alphabet for spaces" do
+      _(-> {
+        Hashids2.new("", 0, 'abc odefghijklmnopqrstuv')
+      }).must_raise Hashids2::AlphabetError
+    end
+  end
+
+  describe "encode" do
+    it "encodes a single number" do
+      _(hashids.encode(12345)).must_equal 'NkK9'
+
+      hashids.tap do |h|
+        _(h.encode(-1)).must_equal          ''
+        _(h.encode(1)).must_equal           'NV'
+        _(h.encode(22)).must_equal          'K4'
+        _(h.encode(333)).must_equal         'OqM'
+        _(h.encode(9999)).must_equal        'kQVg'
+        _(h.encode(123_000)).must_equal     '58LzD'
+        _(h.encode(456_000_000)).must_equal '5gn6mQP'
+        _(h.encode(987_654_321)).must_equal 'oyjYvry'
+      end
+    end
+
+    it "can encode a list of numbers" do
+      hashids.tap do |h|
+        _(h.encode(1,2,3)).must_equal "laHquq"
+        _(h.encode(2,4,6)).must_equal "44uotN"
+        _(h.encode(99,25)).must_equal "97Jun"
+
+        _(h.encode(1337,42,314)).
+          must_equal "7xKhrUxm"
+
+        _(h.encode(683, 94108, 123, 5)).
+          must_equal "aBMswoO2UB3Sj"
+
+        _(h.encode(547, 31, 241271, 311, 31397, 1129, 71129)).
+          must_equal "3RoSDhelEyhxRsyWpCx5t1ZK"
+
+        _(h.encode(21979508, 35563591, 57543099, 93106690, 150649789)).
+          must_equal "p2xkL3CK33JjcrrZ8vsw4YRZueZX9k"
+      end
+    end
+
+    it "can encode a list of numbers passed in as an array" do
+      _(hashids.encode([1,2,3])).must_equal "laHquq"
+    end
+
+    it "can encode  string encoded number" do
+      _(hashids.encode('1')).must_equal "NV"
+      _(hashids.encode('-1')).must_equal ""
+    end
+
+    it "raises exception if integer conversion fails" do
+      _(-> { hashids.encode('-') }).must_raise ArgumentError
+    end
+
+    it "returns an empty string if no numbers" do
+      _(hashids.encode).must_equal ""
+    end
+
+    it "returns an empty string if any of the numbers are negative" do
+      _(hashids.encode(-1)).must_equal ""
+      _(hashids.encode(10,-10)).must_equal ""
+    end
+
+    it "can encode to a minumum length" do
+      h = Hashids2.new(salt, 18)
+      _(h.encode(1)).must_equal "aJEDngB0NV05ev1WwP"
+
+      _(h.encode(4140, 21147, 115975, 678570, 4213597, 27644437)).
+        must_equal "pLMlCWnJSXr1BSpKgqUwbJ7oimr7l6"
+    end
+
+    it "can encode with a custom alphabet" do
+      h = Hashids2.new(salt, 0, "ABCDEFGhijklmn34567890-:")
+      _(h.encode(1,2,3,4,5)).must_equal "6nhmFDikA0"
+    end
+
+    it "does not produce repeating patterns for identical numbers" do
+      _(hashids.encode(5,5,5,5)).must_equal "1Wc8cwcE"
+    end
+
+    it "does not produce repeating patterns for incremented numbers" do
+      _(hashids.encode(*(1..10).to_a)).must_equal "kRHnurhptKcjIDTWC3sx"
+    end
+
+    it "does not produce similarities between incrementing number hashes" do
+      _(hashids.encode(1)).must_equal 'NV'
+      _(hashids.encode(2)).must_equal '6m'
+      _(hashids.encode(3)).must_equal 'yD'
+      _(hashids.encode(4)).must_equal '2l'
+      _(hashids.encode(5)).must_equal 'rD'
+    end
+  end
+
+  describe "encode_hex" do
+    it "encodes hex string" do
+      hashids.tap { |h|
+        _(h.encode_hex("FA")).must_equal    "lzY"
+        _(h.encode_hex("26dd")).must_equal  "MemE"
+        _(h.encode_hex("FF1A")).must_equal  "eBMrb"
+        _(h.encode_hex("12abC")).must_equal "D9NPE"
+        _(h.encode_hex("185b0")).must_equal "9OyNW"
+        _(h.encode_hex("17b8d")).must_equal "MRWNE"
+
+        _(h.encode_hex("1d7f21dd38")).must_equal "4o6Z7KqxE"
+        _(h.encode_hex("20015111d")).must_equal "ooweQVNB"
+      }
+    end
+
+    it "returns an empty string if passed non-hex string" do
+      _(hashids.encode_hex("XYZ123")).must_equal ""
+    end
+  end
+
+  describe "decode" do
+    it "decodes an encoded number" do
+      _(hashids.decode("NkK9")).must_equal [12345]
+      _(hashids.decode("5O8yp5P")).must_equal [666555444]
+      _(hashids.decode("KVO9yy1oO5j")).must_equal [666555444333222]
+
+      hashids.tap { |h|
+        _(h.decode("Wzo")).must_equal [1337]
+        _(h.decode("DbE")).must_equal [808]
+        _(h.decode("yj8")).must_equal [303]
+      }
+    end
+
+    it "decodes a list of encoded numbers" do
+      _(hashids.decode("1gRYUwKxBgiVuX")).must_equal [66655,5444333,2,22]
+      _(hashids.decode('aBMswoO2UB3Sj')).must_equal [683, 94108, 123, 5]
+
+      hashids.tap { |h|
+        _(h.decode('jYhp')).must_equal [3, 4]
+        _(h.decode('k9Ib')).must_equal [6, 5]
+
+        _(h.decode('EMhN')).must_equal [31, 41]
+        _(h.decode('glSgV')).must_equal [13, 89]
+      }
+    end
+
+    it "does not decode with a different salt" do
+      peppers = Hashids2.new('this is my pepper')
+
+      _(hashids.decode('NkK9')).must_equal [12345]
+      _(peppers.decode('NkK9')).must_equal []
+    end
+
+    it "can decode from a hash with a minimum length" do
+      h = Hashids2.new(salt, 8)
+      _(h.decode("gB0NV05e")).must_equal [1]
+
+      _(h.decode("mxi8XH87")).must_equal [25, 100, 950]
+      _(h.decode("KQcmkIW8hX")).must_equal [5,200,195, 1]
+    end
+
+    it "handles invalid input by raising InputError" do
+      _(-> { hashids.decode('asdf-') }).must_raise Hashids2::InputError
+    end
+  end
+
+  describe "decode_hex" do
+    it "decodes hex string" do
+      _(hashids.decode_hex("lzY")).must_equal "FA"
+      _(hashids.decode_hex("eBMrb")).must_equal "FF1A"
+      _(hashids.decode_hex("D9NPE")).must_equal "12ABC"
+    end
+  end
+
+  describe "setup" do
+    it "raises an exception if the alphabet has less than 16 unique chars" do
+      _(-> { Hashids2.new('salt', 0, 'abc') }).
+        must_raise Hashids2::AlphabetError
+    end
+  end
+
+  describe "validation of attributes" do
+    it "raises an ArgumentError unless the salt is a String" do
+      _(-> { Hashids2.new(:not_a_string) }).
+        must_raise Hashids2::SaltError
+    end
+
+    it "raises an ArgumentError unless the min_length is an Integer" do
+      _(-> { Hashids2.new('salt', :not_an_integer)}).
+        must_raise Hashids2::MinLengthError
+    end
+
+    it "raises an ArgumentError unless the alphabet is a String" do
+      _(-> { Hashids2.new('salt', 2, :not_a_string) }).
+        must_raise Hashids2::AlphabetError
+    end
+  end
+
+  describe "protected methods" do
+    describe "unhash" do
+      it "unhashes" do
+        _(hashids.send(:unhash, 'bb',     'abc')).must_equal 4
+        _(hashids.send(:unhash, 'aaa',    'abc')).must_equal 0
+        _(hashids.send(:unhash, 'cba',    'abc')).must_equal 21
+        _(hashids.send(:unhash, 'cbaabc', 'abc')).must_equal 572
+        _(hashids.send(:unhash, 'aX11b',  'abcXYZ123')).must_equal 2728
+      end
+    end
+
+    describe "internal_decode" do
+      it "decodes" do
+        _(hashids.send(:internal_decode, 'NV', alphabet.chars)).must_equal [1]
+      end
+    end
+
+    describe "consistent_shuffle" do
+      let(:salt_chars) { salt.chars }
+
+      it "returns the alphabet if empty salt" do
+        _(hashids.send(:consistent_shuffle, default_alphabet.chars, [], nil, 0)).
+          must_equal default_alphabet.chars
+      end
+
+      it "shuffles consistently" do
+        _(hashids.send(:consistent_shuffle,    'ab'.chars, salt_chars, nil, salt_chars.length)).must_equal 'ba'.chars
+        _(hashids.send(:consistent_shuffle,   'abc'.chars, salt_chars, nil, salt_chars.length)).must_equal 'bca'.chars
+        _(hashids.send(:consistent_shuffle,  'abcd'.chars, salt_chars, nil, salt_chars.length)).must_equal 'cadb'.chars
+        _(hashids.send(:consistent_shuffle, 'abcde'.chars, salt_chars, nil, salt_chars.length)).must_equal 'dceba'.chars
+
+        _(hashids.send(:consistent_shuffle, default_alphabet.chars, 'salt'.chars, nil, 4)).
+          must_equal "f17a8zvCwo0iuqYDXlJ4RmAS2end5ghTcpjbOWLK9GFyE6xUI3ZBMQtPsNHrkV".chars
+
+        _(hashids.send(:consistent_shuffle, 'abcdefghijklmnopqrstuvwxyz'.chars, salt_chars[0..-3], salt_chars[-2..], salt_chars.length)).
+          must_equal 'fcaodykrgqvblxjwmtupzeisnh'.chars
+      end
+    end
+
+    describe "hash_one_number" do
+      it "hashes" do
+        _(hashids.send(:hash_one_number,      12, 'abcdefg', 7)).must_equal "bf"
+        _(hashids.send(:hash_one_number,      42, 'abcdefg', 7)).must_equal "ga"
+        _(hashids.send(:hash_one_number,     123, 'abcdefg', 7)).must_equal "cde"
+        _(hashids.send(:hash_one_number,    1024, 'abcdefg', 7)).must_equal "cggc"
+        _(hashids.send(:hash_one_number,  950000, 'abcdefg', 7)).must_equal "bbadeefc"
+        _(hashids.send(:hash_one_number,  950000, 'åäö-ÅÄÖ', 7)).must_equal "ääå-ÅÅÄö"
+        _(hashids.send(:hash_one_number, 3500000, 'abcdefg', 7)).must_equal "ebfbfaea"
+        _(hashids.send(:hash_one_number, 3500000, 'Xyz01-å', 7)).must_equal "1y-y-X1X"
+      end
+    end
+
+    describe "unhash" do
+      it "unhashes" do
+        _(hashids.send(:unhash, 'abbd', 'abcdefg')).must_equal 59
+        _(hashids.send(:unhash, 'abcd', 'abcdefg')).must_equal 66
+        _(hashids.send(:unhash, 'acac', 'abcdefg')).must_equal 100
+        _(hashids.send(:unhash, 'acfg', 'abcdefg')).must_equal 139
+        _(hashids.send(:unhash, 'x21y', 'xyz1234')).must_equal 218
+        _(hashids.send(:unhash, 'yy44', 'xyz1234')).must_equal 440
+        _(hashids.send(:unhash, '1xzz', 'xyz1234')).must_equal 1045
+      end
+    end
+  end
+end

--- a/spec/hashids3_spec.rb
+++ b/spec/hashids3_spec.rb
@@ -1,0 +1,328 @@
+# encoding: utf-8
+
+require "minitest/autorun"
+require "minitest/spec"
+
+require_relative "../lib/hashids3"
+
+describe Hashids3 do
+  let(:salt)              { 'this is my salt' }
+  let(:seps)              { 'UHuhtcITCsFifS'  }
+  let(:guards)            { 'AdG0'            }
+  let(:hashids)           { Hashids3.new(salt) }
+
+  let(:default_seps) {
+    "cfhistuCFHISTU"
+  }
+
+  let(:default_alphabet)  {
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+  }
+
+  let(:alphabet)          {
+    "5N6y2rljDQak4xgzn8ZR1oKYLmJpEbVq3OBv9WwXPMe7"
+  }
+
+  describe "setup" do
+    it "has a default alphabet" do
+      _(Hashids3::DEFAULT_ALPHABET).must_equal default_alphabet
+    end
+
+    it "has default separators" do
+      _(Hashids3::DEFAULT_SEPS).must_equal default_seps
+    end
+
+    it "has a default salt" do
+      _(Hashids3.new.encode(1,2,3)).must_equal "o2fXhV"
+    end
+
+    it "has the correct salt" do
+      _(hashids.instance_variable_get(:@salt)).must_equal salt
+    end
+
+    it "defaults to a min_length of 0" do
+      _(hashids.instance_variable_get(:@min_hash_length)).must_equal 0
+    end
+
+    it "generates the correct seps" do
+      _(hashids.instance_variable_get(:@seps)).must_equal seps.chars
+    end
+
+    it "generates the correct @guards" do
+      _(hashids.instance_variable_get(:@guards)).must_equal guards.chars
+    end
+
+    it "generates the correct alphabet" do
+      _(hashids.instance_variable_get(:@alphabet)).must_equal alphabet.chars
+    end
+
+    it "has a minimum alphabet length" do
+      _(-> {
+        Hashids3.new("", 0, 'shortalphabet')
+      }).must_raise Hashids3::AlphabetError
+    end
+
+    it "has a final alphabet length that can be shorter than the minimum" do
+      _(Hashids3.new("this is my salt", 0, 'cfhistuCFHISTU01').
+        alphabet).must_equal "10"
+    end
+
+    it "checks the alphabet for spaces" do
+      _(-> {
+        Hashids3.new("", 0, 'abc odefghijklmnopqrstuv')
+      }).must_raise Hashids3::AlphabetError
+    end
+  end
+
+  describe "encode" do
+    it "encodes a single number" do
+      _(hashids.encode(12345)).must_equal 'NkK9'
+
+      hashids.tap do |h|
+        _(h.encode(-1)).must_equal          ''
+        _(h.encode(1)).must_equal           'NV'
+        _(h.encode(22)).must_equal          'K4'
+        _(h.encode(333)).must_equal         'OqM'
+        _(h.encode(9999)).must_equal        'kQVg'
+        _(h.encode(123_000)).must_equal     '58LzD'
+        _(h.encode(456_000_000)).must_equal '5gn6mQP'
+        _(h.encode(987_654_321)).must_equal 'oyjYvry'
+      end
+    end
+
+    it "can encode a list of numbers" do
+      hashids.tap do |h|
+        _(h.encode(1,2,3)).must_equal "laHquq"
+        _(h.encode(2,4,6)).must_equal "44uotN"
+        _(h.encode(99,25)).must_equal "97Jun"
+
+        _(h.encode(1337,42,314)).
+          must_equal "7xKhrUxm"
+
+        _(h.encode(683, 94108, 123, 5)).
+          must_equal "aBMswoO2UB3Sj"
+
+        _(h.encode(547, 31, 241271, 311, 31397, 1129, 71129)).
+          must_equal "3RoSDhelEyhxRsyWpCx5t1ZK"
+
+        _(h.encode(21979508, 35563591, 57543099, 93106690, 150649789)).
+          must_equal "p2xkL3CK33JjcrrZ8vsw4YRZueZX9k"
+      end
+    end
+
+    it "can encode a list of numbers passed in as an array" do
+      _(hashids.encode([1,2,3])).must_equal "laHquq"
+    end
+
+    it "can encode  string encoded number" do
+      _(hashids.encode('1')).must_equal "NV"
+      _(hashids.encode('-1')).must_equal ""
+    end
+
+    it "raises exception if integer conversion fails" do
+      _(-> { hashids.encode('-') }).must_raise ArgumentError
+    end
+
+    it "returns an empty string if no numbers" do
+      _(hashids.encode).must_equal ""
+    end
+
+    it "returns an empty string if any of the numbers are negative" do
+      _(hashids.encode(-1)).must_equal ""
+      _(hashids.encode(10,-10)).must_equal ""
+    end
+
+    it "can encode to a minumum length" do
+      h = Hashids3.new(salt, 18)
+      _(h.encode(1)).must_equal "aJEDngB0NV05ev1WwP"
+
+      _(h.encode(4140, 21147, 115975, 678570, 4213597, 27644437)).
+        must_equal "pLMlCWnJSXr1BSpKgqUwbJ7oimr7l6"
+    end
+
+    it "can encode with a custom alphabet" do
+      h = Hashids3.new(salt, 0, "ABCDEFGhijklmn34567890-:")
+      _(h.encode(1,2,3,4,5)).must_equal "6nhmFDikA0"
+    end
+
+    it "does not produce repeating patterns for identical numbers" do
+      _(hashids.encode(5,5,5,5)).must_equal "1Wc8cwcE"
+    end
+
+    it "does not produce repeating patterns for incremented numbers" do
+      _(hashids.encode(*(1..10).to_a)).must_equal "kRHnurhptKcjIDTWC3sx"
+    end
+
+    it "does not produce similarities between incrementing number hashes" do
+      _(hashids.encode(1)).must_equal 'NV'
+      _(hashids.encode(2)).must_equal '6m'
+      _(hashids.encode(3)).must_equal 'yD'
+      _(hashids.encode(4)).must_equal '2l'
+      _(hashids.encode(5)).must_equal 'rD'
+    end
+  end
+
+  describe "encode_hex" do
+    it "encodes hex string" do
+      hashids.tap { |h|
+        _(h.encode_hex("FA")).must_equal    "lzY"
+        _(h.encode_hex("26dd")).must_equal  "MemE"
+        _(h.encode_hex("FF1A")).must_equal  "eBMrb"
+        _(h.encode_hex("12abC")).must_equal "D9NPE"
+        _(h.encode_hex("185b0")).must_equal "9OyNW"
+        _(h.encode_hex("17b8d")).must_equal "MRWNE"
+
+        _(h.encode_hex("1d7f21dd38")).must_equal "4o6Z7KqxE"
+        _(h.encode_hex("20015111d")).must_equal "ooweQVNB"
+      }
+    end
+
+    it "returns an empty string if passed non-hex string" do
+      _(hashids.encode_hex("XYZ123")).must_equal ""
+    end
+  end
+
+  describe "decode" do
+    it "decodes an encoded number" do
+      _(hashids.decode("NkK9")).must_equal [12345]
+      _(hashids.decode("5O8yp5P")).must_equal [666555444]
+      _(hashids.decode("KVO9yy1oO5j")).must_equal [666555444333222]
+
+      hashids.tap { |h|
+        _(h.decode("Wzo")).must_equal [1337]
+        _(h.decode("DbE")).must_equal [808]
+        _(h.decode("yj8")).must_equal [303]
+      }
+    end
+
+    it "decodes a list of encoded numbers" do
+      _(hashids.decode("1gRYUwKxBgiVuX")).must_equal [66655,5444333,2,22]
+      _(hashids.decode('aBMswoO2UB3Sj')).must_equal [683, 94108, 123, 5]
+
+      hashids.tap { |h|
+        _(h.decode('jYhp')).must_equal [3, 4]
+        _(h.decode('k9Ib')).must_equal [6, 5]
+
+        _(h.decode('EMhN')).must_equal [31, 41]
+        _(h.decode('glSgV')).must_equal [13, 89]
+      }
+    end
+
+    it "does not decode with a different salt" do
+      peppers = Hashids3.new('this is my pepper')
+
+      _(hashids.decode('NkK9')).must_equal [12345]
+      _(peppers.decode('NkK9')).must_equal []
+    end
+
+    it "can decode from a hash with a minimum length" do
+      h = Hashids3.new(salt, 8)
+      _(h.decode("gB0NV05e")).must_equal [1]
+
+      _(h.decode("mxi8XH87")).must_equal [25, 100, 950]
+      _(h.decode("KQcmkIW8hX")).must_equal [5,200,195, 1]
+    end
+
+    it "handles invalid input by raising InputError" do
+      _(-> { hashids.decode('asdf-') }).must_raise Hashids3::InputError
+    end
+  end
+
+  describe "decode_hex" do
+    it "decodes hex string" do
+      _(hashids.decode_hex("lzY")).must_equal "FA"
+      _(hashids.decode_hex("eBMrb")).must_equal "FF1A"
+      _(hashids.decode_hex("D9NPE")).must_equal "12ABC"
+    end
+  end
+
+  describe "setup" do
+    it "raises an exception if the alphabet has less than 16 unique chars" do
+      _(-> { Hashids3.new('salt', 0, 'abc') }).
+        must_raise Hashids3::AlphabetError
+    end
+  end
+
+  describe "validation of attributes" do
+    it "raises an ArgumentError unless the salt is a String" do
+      _(-> { Hashids3.new(:not_a_string) }).
+        must_raise Hashids3::SaltError
+    end
+
+    it "raises an ArgumentError unless the min_length is an Integer" do
+      _(-> { Hashids3.new('salt', :not_an_integer)}).
+        must_raise Hashids3::MinLengthError
+    end
+
+    it "raises an ArgumentError unless the alphabet is a String" do
+      _(-> { Hashids3.new('salt', 2, :not_a_string) }).
+        must_raise Hashids3::AlphabetError
+    end
+  end
+
+  describe "protected methods" do
+    describe "unhash" do
+      it "unhashes" do
+        _(hashids.send(:unhash, 'bb',     'abc')).must_equal 4
+        _(hashids.send(:unhash, 'aaa',    'abc')).must_equal 0
+        _(hashids.send(:unhash, 'cba',    'abc')).must_equal 21
+        _(hashids.send(:unhash, 'cbaabc', 'abc')).must_equal 572
+        _(hashids.send(:unhash, 'aX11b',  'abcXYZ123')).must_equal 2728
+      end
+    end
+
+    describe "internal_decode" do
+      it "decodes" do
+        _(hashids.send(:internal_decode, 'NV', alphabet.chars)).must_equal [1]
+      end
+    end
+
+    describe "consistent_shuffle" do
+      let(:salt_chars) { salt.chars.map(&:ord) }
+      let(:alpha_ords) { default_alphabet.chars.map(&:ord) }
+
+      it "returns the alphabet if empty salt" do
+        _(hashids.send(:consistent_shuffle, alpha_ords, [], nil, 0)).
+          must_equal default_alphabet.chars.map(&:ord)
+      end
+
+      it "shuffles consistently" do
+        _(hashids.send(:consistent_shuffle,    'ab'.chars.map(&:ord), salt_chars, nil, salt_chars.length)).must_equal 'ba'.chars.map(&:ord)
+        _(hashids.send(:consistent_shuffle,   'abc'.chars.map(&:ord), salt_chars, nil, salt_chars.length)).must_equal 'bca'.chars.map(&:ord)
+        _(hashids.send(:consistent_shuffle,  'abcd'.chars.map(&:ord), salt_chars, nil, salt_chars.length)).must_equal 'cadb'.chars.map(&:ord)
+        _(hashids.send(:consistent_shuffle, 'abcde'.chars.map(&:ord), salt_chars, nil, salt_chars.length)).must_equal 'dceba'.chars.map(&:ord)
+
+        _(hashids.send(:consistent_shuffle, alpha_ords, 'salt'.chars.map(&:ord), nil, 4)).
+          must_equal "f17a8zvCwo0iuqYDXlJ4RmAS2end5ghTcpjbOWLK9GFyE6xUI3ZBMQtPsNHrkV".chars.map(&:ord)
+
+        _(hashids.send(:consistent_shuffle, 'abcdefghijklmnopqrstuvwxyz'.chars.map(&:ord), salt_chars[0..-3], salt_chars[-2..], salt_chars.length)).
+          must_equal 'fcaodykrgqvblxjwmtupzeisnh'.chars.map(&:ord)
+      end
+    end
+
+    describe "hash_one_number" do
+      it "hashes" do
+        _(hashids.send(:hash_one_number,      12, 'abcdefg', 7).join).must_equal "bf"
+        _(hashids.send(:hash_one_number,      42, 'abcdefg', 7).join).must_equal "ga"
+        _(hashids.send(:hash_one_number,     123, 'abcdefg', 7).join).must_equal "cde"
+        _(hashids.send(:hash_one_number,    1024, 'abcdefg', 7).join).must_equal "cggc"
+        _(hashids.send(:hash_one_number,  950000, 'abcdefg', 7).join).must_equal "bbadeefc"
+        _(hashids.send(:hash_one_number,  950000, 'åäö-ÅÄÖ', 7).join).must_equal "ääå-ÅÅÄö"
+        _(hashids.send(:hash_one_number, 3500000, 'abcdefg', 7).join).must_equal "ebfbfaea"
+        _(hashids.send(:hash_one_number, 3500000, 'Xyz01-å', 7).join).must_equal "1y-y-X1X"
+      end
+    end
+
+    describe "unhash" do
+      it "unhashes" do
+        _(hashids.send(:unhash, 'abbd', 'abcdefg')).must_equal 59
+        _(hashids.send(:unhash, 'abcd', 'abcdefg')).must_equal 66
+        _(hashids.send(:unhash, 'acac', 'abcdefg')).must_equal 100
+        _(hashids.send(:unhash, 'acfg', 'abcdefg')).must_equal 139
+        _(hashids.send(:unhash, 'x21y', 'xyz1234')).must_equal 218
+        _(hashids.send(:unhash, 'yy44', 'xyz1234')).must_equal 440
+        _(hashids.send(:unhash, '1xzz', 'xyz1234')).must_equal 1045
+      end
+    end
+  end
+end


### PR DESCRIPTION
WIP, currently this is using a copy of `Hashids` to allow me to easily run both implementations side by side

Note: I will likely split this PR into smaller stacked ones shortly.

Some numbers (v1 is original implemation, v2 is the one Im working on):

```
Hashids#encode: 100 numbers
-------------------

Warming up --------------------------------------
                  v1   176.000  i/100ms
                  v2   297.000  i/100ms
Calculating -------------------------------------
                  v1      1.804k (± 1.9%) i/s -      5.456k in   3.025510s
                  v2      3.024k (± 1.8%) i/s -      9.207k in   3.045634s

Comparison:
                  v2:     3024.0 i/s
                  v1:     1804.0 i/s - 1.68x  slower



## Memory:

Calculating -------------------------------------
                  v1   410.384k memsize (     0.000  retained)
                         5.994k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
                  v2    11.024k memsize (     0.000  retained)
                       204.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)

Comparison:
                  v2:      11024 allocated
                  v1:     410384 allocated - 37.23x more
```